### PR TITLE
Single task queue to prevent events being denormalized out of order

### DIFF
--- a/lib/replayHandler.js
+++ b/lib/replayHandler.js
@@ -133,7 +133,8 @@ ReplayHandler.prototype = {
     var self = this;
 
     var evtCount = 0;
-    var queues = {};
+    var eventQueue = [];
+    var eventQueueHandling = false;
 
     var errs = [];
     var doneCalled = true,
@@ -162,8 +163,7 @@ ReplayHandler.prototype = {
           collections[vb.collection.workerId] = vb.collection;
         }
 
-        queues[vb.workerId] = queues[vb.workerId] || [];
-        queues[vb.workerId].push(evt);
+        eventQueue.push({evt: evt, vb: vb});
         evtCount++;
 
         function handleNext () {
@@ -172,8 +172,9 @@ ReplayHandler.prototype = {
             return;
           }
 
-          if (queues[vb.workerId] && queues[vb.workerId].length > 0) {
-            var e = queues[vb.workerId].shift();
+          if (eventQueue.length > 0) {
+            var task = eventQueue.shift();
+            var e = task.evt, vb = task.vb;
             vb.denormalize(e, function (err) {
               --evtCount;
               if (err) {
@@ -183,13 +184,13 @@ ReplayHandler.prototype = {
 
               handleNext();
             });
-          } else if (isHandling[vb.workerId]) {
-            delete isHandling[vb.workerId];
+          } else if (eventQueueHandling) {
+            eventQueueHandling = false;
           }
         }
 
-        if (!isHandling[vb.workerId]) {
-          isHandling[vb.workerId] = true;
+        if (!eventQueueHandling) {
+          eventQueueHandling = true;
           process.nextTick(handleNext);
         }
       });


### PR DESCRIPTION
Hi! I just ran into an issue with the denormalizer. Replaying events by using `replayStreamed` might lead to events being denormalized out of order (if they are denormalized by different ViewBuilders).

This commit fixes it. Please have a look at it.

See you on Monday!
