### PR TITLE
add noAutoCreate option to view builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ It can be very useful as eventdenormalizer component if you work with (d)ddd, cq
 	  // [set 1](https://github.com/adrai/node-cqrs-eventdenormalizer/tree/master/test/integration/fixture/set1) or
 	  // [set 2](https://github.com/adrai/node-cqrs-eventdenormalizer/tree/master/test/integration/fixture/set2)
 	  denormalizerPath: '/path/to/my/files',
-	  
+
 	  // optional, default is 'commandRejected'
 	  // will be used to catch AggregateDestroyedError from cqrs-domain
 	  commandRejectedEventName: 'rejectedCommand',
-	  
+
 	  // optional, default is 800
 	  // if using in scaled systems, this module tries to catch the concurrency issues and
 	  // retries to handle the event after a timeout between 0 and the defined value
 	  retryOnConcurrencyTimeout: 1000,
-	  
+
 	  // optional, default is in-memory
 	  // currently supports: mongodb, redis, tingodb, couchdb, azuretable and inmemory
 	  // hint: [viewmodel](https://github.com/adrai/node-viewmodel#connecting-to-any-repository-mongodb-in-the-example--modewrite)
@@ -40,14 +40,14 @@ It can be very useful as eventdenormalizer component if you work with (d)ddd, cq
 	    // username: 'technicalDbUser',                // optional
 	    // password: 'secret'                          // optional
 	  },
-	  
+
 	  // optional, default is in-memory
 	  // currently supports: mongodb, redis, tingodb and inmemory
 	  // hint settings like: [eventstore](https://github.com/adrai/node-eventstore#provide-implementation-for-storage)
 	  revisionGuard: {
 	    queueTimeout: 1000,                         // optional, timeout for non-handled events in the internal in-memory queue
 	    queueTimeoutMaxLoops: 3                     // optional, maximal loop count for non-handled event in the internal in-memory queue
-	  
+
 	    type: 'redis',
 	    host: 'localhost',                          // optional
 	    port: 6379,                                 // optional
@@ -65,26 +65,26 @@ It can be very useful as eventdenormalizer component if you work with (d)ddd, cq
 	denormalizer.repository.on('connect', function() {
 	  console.log('repository connected');
 	});
-	
+
 	denormalizer.repository.on('disconnect', function() {
 	  console.log('repository disconnected');
 	});
-	
+
 	// revisionGuardStore
 	denormalizer.revisionGuardStore.on('connect', function() {
 	  console.log('revisionGuardStore connected');
 	});
-	
+
 	denormalizer.revisionGuardStore.on('disconnect', function() {
 	  console.log('revisionGuardStore disconnected');
 	});
-	
-	
+
+
 	// anything (repository or revisionGuardStore)
 	denormalizer.on('connect', function() {
 	  console.log('something connected');
 	});
-	
+
 	denormalizer.on('disconnect', function() {
 	  console.log('something disconnected');
 	});
@@ -98,32 +98,32 @@ The values describes the path to that property in the event message.
 	  // will use the command id as correlationId, so you can match it in the sender
 	  // will be used to copy the correlationId to the notification
 	  correlationId: 'correlationId',
-	
+
 	  // optional, default is 'id'
 	  id: 'id',
-	
+
 	  // optional, default is 'name'
 	  name: 'name',
-	
+
 	  // optional, default is 'aggregate.id'
 	  aggregateId: 'aggregate.id',
-	
+
 	  // optional
 	  context: 'context.name',
-	
+
 	  // optional
 	  aggregate: 'aggregate.name',
-	
+
 	  // optional, default is 'payload'
 	  payload: 'payload',
-	
+
 	  // optional, default is 'revision'
 	  // will represent the aggregate revision, can be used in next command
 	  revision: 'revision',
-	
+
 	  // optional
 	  version: 'version',
-	
+
 	  // optional, if defined the values of the command will be copied to the event (can be used to transport information like userId, etc..)
 	  meta: 'meta'
 	});
@@ -137,38 +137,38 @@ The values describes the path to that property in the notification message.
 	  // will use the command id as correlationId, so you can match it in the sender
 	  // will be used to copy the correlationId from the event
 	  correlationId: 'correlationId',
-	
+
 	  // optional, default is 'id'
 	  id: 'id',
-	
+
 	  // optional, default is 'name'
 	  action: 'name',
-	
+
 	  // optional, default is 'collection'
 	  collection: 'collection',
-	
+
 	  // optional, default is 'payload'
 	  payload: 'payload',
-	
+
 	  // optional, will be copied from event
 	  aggregateId: 'meta.aggregate.id',
-	
+
 	  // optional, will be copied from event
 	  context: 'meta.context.name',
-	
+
 	  // optional, will be copied from event
 	  aggregate: 'meta.aggregate.name',
-	
+
 	  // optional, will be copied from event
 	  // will represent the aggregate revision, can be used in next command
 	  revision: 'meta.aggregate.revision',
-	
+
 	  // optional, will be copied from event
 	  eventId: 'meta.event.id',
-	
+
 	  // optional, will be copied from event
 	  event: 'meta.event.name',
-	
+
 	  // optional, if defined the values of the event will be copied to the notification (can be used to transport information like userId, etc..)
 	  meta: 'meta'
 	});
@@ -258,9 +258,9 @@ The values describes the path to that property in the notification message.
 	denormalizer.init(function (err) {
 	  // this callback is called when all is ready...
 	});
-	
+
 	// or
-	
+
 	denormalizer.init(); // callback is optional
 
 
@@ -394,13 +394,13 @@ After the initialization you can request the denormalizer information:
 	module.exports = require('cqrs-eventdenormalizer').defineCollection({
 	  // optional, default is folder name
     name: 'personDetail'
-	  
+
 	  // optional, default ''
 	  defaultPayload: 'payload',
-	
+
 	  // optional, default false
 	  noReplay: false,
-	
+
 	  // indexes: [ // for mongodb
 	  //   'profileId',
 	  //   // or:
@@ -409,7 +409,7 @@ After the initialization you can request the denormalizer information:
 	  //   { index: {profileId: 1}, options: {} }
 	  // ]
 	},
-	
+
 	// optionally, define some initialization data for new view models...
 	{
 	  emails: ['default@mycomp.org'],
@@ -433,19 +433,22 @@ But be careful with this!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  version: 2,
-	
+
 	  // optional, if not defined or not found it will generate a new viewmodel with new id
 	  id: 'aggregate.id',
-	
+
+    // optional, suppresses auto-creation of new view model if none matching the id can be found
+    autoCreate: false,
+
 	  // optional, if not defined it will pass the whole event...
 	  payload: 'payload'
 	}, function (data, vm) { // instead of function you can define
@@ -465,19 +468,19 @@ A lot of viewmodels can slow down the denormalization process!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  version: 2,
-	
+
 	  // optional, if not defined or not found it will generate a new viewmodel with new id
 	  query: { group: 'admins' },
-	
+
 	  // optional, if not defined it will pass the whole event...
 	  payload: 'payload'
 	}, function (data, vm) { // instead of function you can define
@@ -511,17 +514,17 @@ A lot of viewmodels can slow down the denormalization process!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  // if set to -1, it will ignore the version
 	  version: 2//,
-	
+
 	  // optional, if not defined it will pass the whole event...
 	  // payload: 'payload'
 	}, function (evt, col, callback) {
@@ -536,20 +539,20 @@ A lot of viewmodels can slow down the denormalization process!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  // if set to -1, it will ignore the version
 	  version: 2,
-	
+
 	  // if defined it will load the viewmodel
 	  id: 'payload.id'//,
-	
+
 	  // optional, if not defined it will pass the whole event...
 	  // payload: 'payload'
 	},
@@ -564,20 +567,20 @@ A lot of viewmodels can slow down the denormalization process!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  // if set to -1, it will ignore the version
 	  version: 2,
-	
+
 	  // if defined it will load the viewmodel
 	  id: 'payload.id'//,
-	
+
 	  // optional, if not defined it will pass the whole event...
 	  // payload: 'payload'
 	},
@@ -592,17 +595,17 @@ A lot of viewmodels can slow down the denormalization process!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  // if set to -1, it will ignore the version
 	  version: 2//,
-	
+
 	  // optional, if not defined it will pass the whole event...
 	  // payload: 'payload'
 	}, function (evt) {
@@ -616,17 +619,17 @@ A lot of viewmodels can slow down the denormalization process!
 	  // optional, default is file name without extension,
 	  // if name is '' it will handle all events that matches
 	  name: 'enteredNewPerson',
-	
+
 	  // optional
 	  aggregate: 'person',
-	
+
 	  // optional
 	  context: 'hr',
-	
+
 	  // optional, default is 0
 	  // if set to -1, it will ignore the version
 	  version: 2//,
-	
+
 	  // optional, if not defined it will pass the whole event...
 	  // payload: 'payload'
 	}, function (evt, callback) {
@@ -646,7 +649,7 @@ Replay whenever you want...
 or when catching some events:
 
 	denormalizer.onEventMissing(function (info, evt) {
-	
+
 	  // grab the missing events, depending from info values...
 	  // info.aggregateId
 	  // info.aggregateRevision
@@ -657,21 +660,21 @@ or when catching some events:
 	  denormalizer.handle(missingEvent, function (err) {
 	    if (err) { console.log(err); }
 	  });
-	
+
 	});
 
 ### streamed
 
 	denormalizer.replayStreamed(function (replay, done) {
-	
+
 	  replay(evt1);
 	  replay(evt2);
 	  replay(evt3);
-	
+
 	  done(function (err) {
 	    if (err) { console.log(err); }
 	  });
-	
+
 	});
 
 ### if you want to clear the readModel before replaying...

--- a/lib/definitions/viewBuilder.js
+++ b/lib/definitions/viewBuilder.js
@@ -42,7 +42,8 @@ function ViewBuilder (meta, denormFn) {
   this.context = meta.context || null;
   this.id = meta.id || null;
   this.query = meta.query || null;
-  this.noAutoCreate = meta.noAutoCreate || false;
+
+  if (typeof meta.autoCreate === 'undefined') { this.autoCreate = true; }
 
   if (_.isString(denormFn)) {
     if (denormFn === 'delete') {
@@ -420,7 +421,7 @@ _.extend(ViewBuilder.prototype, {
           return callback(err);
         }
 
-        if (vm.actionOnCommit === 'create' && self.noAutoCreate) {
+        if (vm.actionOnCommit === 'create' && !self.autoCreate) {
           callback(null, []);
           return;
         }

--- a/lib/definitions/viewBuilder.js
+++ b/lib/definitions/viewBuilder.js
@@ -42,6 +42,7 @@ function ViewBuilder (meta, denormFn) {
   this.context = meta.context || null;
   this.id = meta.id || null;
   this.query = meta.query || null;
+  this.noAutoCreate = meta.noAutoCreate || false;
 
   if (_.isString(denormFn)) {
     if (denormFn === 'delete') {
@@ -417,6 +418,11 @@ _.extend(ViewBuilder.prototype, {
         if (err) {
           debug(err);
           return callback(err);
+        }
+
+        if (vm.actionOnCommit === 'create' && self.noAutoCreate) {
+          callback(null, []);
+          return;
         }
 
         self.handleOne(vm, evt, function (err, notification) {


### PR DESCRIPTION
Adds an option to `defineViewBuilder` that disables automatic creation of view models. So you may update a view model only if it has been created previously, for instance.

Cheers