### PR TITLE
Fixed issue with error handling in event dispatch.

### DIFF
--- a/lib/eventDispatcher.js
+++ b/lib/eventDispatcher.js
@@ -136,7 +136,7 @@ EventDispatcher.prototype = {
       })
     }, function () {
       if (errs.length === 0) {
-        errs = null;
+        return callback(null, notifications);
       }
       callback(errs, notifications);
     });


### PR DESCRIPTION
In an async.series structure, which executes its handlers in parallel, it could happen that one handler tried pushing an element to a variable containing an errors array (line 129), after another handler had reassigned that variable to null (line 139). This lead to a TypeError obscuring the original error the user is interested in.