### PR TITLE
Fail early if a custom event extender did not pass on the extended event

### DIFF
--- a/lib/denormalizer.js
+++ b/lib/denormalizer.js
@@ -481,6 +481,9 @@ _.extend(Denormalizer.prototype, {
 
         function (callback) {
           self.extendEvent(evt, function (err, extEvt) {
+            if (!err && !extEvt) {
+              return callback(new Error('Event-Extender did not pass on the extended event! Make sure to invoke the callback with the extended event or an error.'));
+            }
             extendedEvent = extEvt;
             callback(err);
           });


### PR DESCRIPTION
Otherwise, this will fail with "TypeError: Cannot read property 'name' of undefined" in denormalizer.js:76