### PR TITLE
:sparkles: Allow to set dynamo DB document client options

### DIFF
--- a/lib/revisionGuardStore/databases/dynamodb.js
+++ b/lib/revisionGuardStore/databases/dynamodb.js
@@ -36,7 +36,9 @@ _.extend(DynamoDB.prototype, {
   connect: function(callback) {
     var self = this;
     self.client = new aws.DynamoDB(self.options.endpointConf);
-    self.documentClient = new aws.DynamoDB.DocumentClient({ service: self.client });
+    var clientDefaults = { service: self.client }
+    var clientOptions = _.defaults(this.options.clientConf, clientDefaults);
+    self.documentClient = new aws.DynamoDB.DocumentClient(clientOptions);
     self.isConnected = true;
     self.emit('connect');
     if (callback) callback(null, self);


### PR DESCRIPTION
I need this to provide the DocumentClient with the option
convertEmptyValues. See https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#constructor-property