### PR TITLE
Fix preExtendEvent callback errs param in dispatch func

### DIFF
--- a/lib/denormalizer.js
+++ b/lib/denormalizer.js
@@ -516,7 +516,7 @@ _.extend(Denormalizer.prototype, {
 
       if (err) {
         debug(err);
-        if (callback) callback([errs], evt, []);
+        if (callback) callback([err], evt, []);
         return;
       }
 


### PR DESCRIPTION
### DESCRIPTION
The issue here is if there is error happened in the pre event extender. The callback with happen with param name err. However the code in the denormalizer dispatch func call it with [errs] which will cause ReferenceError.

### STEPS
1. Define an pre event extender as 
~~~~
module.exports = require('cqrs-eventdenormalizer').definePreEventExtender({
    name: 'testCreated',
    aggregate: 'test',
    context: 'core'
}, function(evt, col, callback) {
    callback(new Error('This is a test'), evt);;
});
~~~~

2. Call the denormalizer dispatch

### EXPECTED
Handle the error gracefully

### OBSERVATIONS
"ReferenceError: errs is not defined.