### PR TITLE
Increase DynamoDB performance

### DIFF
--- a/lib/revisionGuardStore/databases/dynamodb.js
+++ b/lib/revisionGuardStore/databases/dynamodb.js
@@ -5,7 +5,8 @@ var util = require('util'),
   async = require('async'),
   _ = require('lodash'),
   uuid = require('uuid').v4,
-  aws = Store.use('aws-sdk');
+  aws = Store.use('aws-sdk'),
+  collections = [];
 
 function DynamoDB(options) {
   var awsConf = {
@@ -184,6 +185,11 @@ _.extend(DynamoDB.prototype, {
 
   checkConnection: function(callback) {
     var self = this;
+
+    if (collections.indexOf(self.collectionName) >= 0) {
+      return callback(null);
+    }
+
     createTableIfNotExists(
       self.client, 
       RevisionTableDefinition(self.options.tableName, self.options), 
@@ -194,8 +200,14 @@ _.extend(DynamoDB.prototype, {
           if (err.code === 'ResourceInUseException') {
             return callback(null);
           }
+
           return callback(err);
         }
+
+        if (collections.indexOf(self.collectionName) < 0) {
+          collections.push(self.collectionName);
+        }
+
         return callback(null);
       }
     );


### PR DESCRIPTION
So far any interaction with the DynamoDB tried to make sure that the table is existing, and if that is not the case it would create the table.

However as DynamoDB is an HTTP based API this would also always mean that an additional API request is done, increasing the time needed to handle request.

This PR makes sure that the table is only checked once for existence.