### PR TITLE
skipAfterCommit

### DIFF
--- a/lib/definitions/viewBuilder.js
+++ b/lib/definitions/viewBuilder.js
@@ -101,7 +101,7 @@ function ViewBuilder (meta, denormFn) {
 
   this.defineShouldHandle(truthyShouldHandle);
 
-  this.defineShouldHandleEvent(truthyShouldHandleEvent);  
+  this.defineShouldHandleEvent(truthyShouldHandleEvent);
 
   this.onAfterCommit(function (evt, vm) {});
 }
@@ -392,7 +392,7 @@ _.extend(ViewBuilder.prototype, {
               return callback(err);
             }
 
-            if (!self.options.callOnAfterCommitDuringReplay && self.collection.isReplaying) {
+            if ((!self.options.callOnAfterCommitDuringReplay && self.collection.isReplaying) || self.options.skipAfterCommit) {
               return callback(null, notification);
             }
 

--- a/lib/denormalizer.js
+++ b/lib/denormalizer.js
@@ -45,7 +45,7 @@ function Denormalizer(options) {
   var defaults = {
     retryOnConcurrencyTimeout: 800,
     commandRejectedEventName: 'commandRejected',
-    callOnAfterCommitDuringReplay: false
+    callOnAfterCommitDuringReplay: false,
     skipAfterCommit: false
   };
 

--- a/lib/denormalizer.js
+++ b/lib/denormalizer.js
@@ -25,7 +25,7 @@ function createStructureLoader (options) {
   }
   return structureLoader;
 }
-  
+
 /**
  * Denormalizer constructor
  * @param {Object} options The options.
@@ -46,6 +46,7 @@ function Denormalizer(options) {
     retryOnConcurrencyTimeout: 800,
     commandRejectedEventName: 'commandRejected',
     callOnAfterCommitDuringReplay: false
+    skipAfterCommit: false
   };
 
   _.defaults(options, defaults);


### PR DESCRIPTION
for continuous rebuilds - a rebuild rebuild that continuous where it left of due to an error - we need the possibility to replay N events using the normal denormalize fn to build up an in-memory revision guard. therefore we also need the possibility to skip afterCommits during that time.