### PR TITLE
skip steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ It can be very useful as eventdenormalizer component if you work with (d)ddd, cq
 	    prefix: 'readmodel_revision',               // optional
 	    timeout: 10000                              // optional
 	    // password: 'secret'                          // optional
-	  }
+	  },
+	  skipExtendEvent: false,						// optional
+	  skipOnEventMissing: false,					// optional
+	  skipOnEvent: false,							// optional
+	  skipOnNotification: false,					// optional
 	});
 
 
@@ -245,6 +249,7 @@ The values describes the path to that property in the notification message.
 	  bus.emit('event', evt);
 	});
 
+
 ### or you can define an asynchronous function
 
 	// pass events to bus
@@ -253,6 +258,9 @@ The values describes the path to that property in the notification message.
 	    callback();
 	  });
 	});
+
+### skip onEvent if provided
+	You can skip onEvent from being called, by adding the `skipOnEvent` option to the denormalizer. Checkout the usage section for more information.
 
 
 ## Wire up notifications [optional]
@@ -272,6 +280,11 @@ The values describes the path to that property in the notification message.
 	  });
 	});
 
+### skip onNotification if provided
+
+	You can skip onNotification from being called, by addding the `skipOnNotification` option to the denormalizer. Checkout the usage section for more information.
+
+
 
 ## Wire up event missing [optional]
 ### you can define a synchronous function
@@ -280,6 +293,9 @@ The values describes the path to that property in the notification message.
 	  console.log(info);
 	  console.log(evt);
 	});
+
+### skip onEventMissing if provided
+	You can skip onEventMissing from being called, by adding the `skipOnEventMissing` option to the denormalizer. Checkout the usage section more information.
 
 
 ## Define default event extension [optional]
@@ -296,6 +312,10 @@ The values describes the path to that property in the notification message.
 	  evt.receiver = [evt.meta.userId];
 	  callback(null, evt);
 	});
+
+### skip default event extensions 
+	You can skip all event extenders and the default extensions from being executed by adding the option `skipExtendEvent` to the denormalizer. Checkout the usage section for more information.
+
 
 
 
@@ -857,6 +877,8 @@ or when catching some events:
 	  });
 
 	});
+
+	you can skip onEventMissing from being called, if provided, by adding the option `skipOnEventMissing` to the denormalizer. Checkout the usage section for more information.
 
 or depending on the last guarded event:
 

--- a/lib/definitions/eventExtender.js
+++ b/lib/definitions/eventExtender.js
@@ -109,7 +109,6 @@ _.extend(EventExtender.prototype, {
    */
   extend: function (evt, callback) {
     var self = this;
-
     var payload = evt;
 
     if (self.payload && self.payload !== '') {

--- a/lib/denormalizer.js
+++ b/lib/denormalizer.js
@@ -197,6 +197,10 @@ _.extend(Denormalizer.prototype, {
       });
     }
 
+    if (this.options.skipOnEvent) {
+      fn = function(evt, callback) { callback (null); };
+    }
+
     this.onEventHandle = fn;
 
     return this;
@@ -215,10 +219,14 @@ _.extend(Denormalizer.prototype, {
     }
 
     if (fn.length === 1) {
-      fn = _.wrap(fn, function(func, evt, callback) {
-        func(evt);
+      fn = _.wrap(fn, function(func, notification, callback) {
+        func(notification);
         callback(null);
       });
+    }
+
+    if (this.options.skipOnNotification) {
+      fn = function(notification, callback) { callback(null); };
     }
 
     this.onNotificationHandle = fn;
@@ -234,8 +242,12 @@ _.extend(Denormalizer.prototype, {
   onEventMissing: function (fn) {
     if (!fn || !_.isFunction(fn)) {
       var err = new Error('Please pass a valid function!');
-      debug(err);
+        debug(err);
       throw err;
+    }
+
+    if (this.options.skipOnEventMissing) {
+      fn = function(info, evt) {};
     }
 
     this.onEventMissingHandle = fn;
@@ -259,6 +271,11 @@ _.extend(Denormalizer.prototype, {
       fn = _.wrap(fn, function(func, evt, callback) {
         callback(null, func(evt));
       });
+    }
+
+    // In case we skip the event extenders, we also have to skip the default extender.
+    if (this.options.skipExtendEvent) {
+      fn = function (evt, callback) { callback(null, evt); };
     }
 
     this.extendEventHandle = fn;
@@ -392,7 +409,7 @@ _.extend(Denormalizer.prototype, {
 
       var eventExtender = self.tree.getEventExtender(self.eventDispatcher.getTargetInformation(evt));
 
-      if (!eventExtender) {
+      if (!eventExtender || self.options.skipExtendEvent) {
         return callback(err, extendedEvent);
       }
 
@@ -537,7 +554,6 @@ _.extend(Denormalizer.prototype, {
 
           function (callback) {
             async.parallel([
-
               function (callback) {
                 async.each(notifications, function (n, callback) {
                   if (self.onNotificationHandle) {


### PR DESCRIPTION
we want to be able to skip the steps that are triggered after the actual denormalizaton within a viewbuilder.
The following steps shall be skipable:
- extendEvent
- onEvent
- onEventMissing
- onNotification